### PR TITLE
Upgrade to C++14 standard (-std=c++14)

### DIFF
--- a/_binding.gyp
+++ b/_binding.gyp
@@ -119,7 +119,7 @@
 		],
 
 		"cflags" : [
-			"-std=c++11"
+			"-std=c++14"
 		],
 		"cflags!" : [
 			"-fno-exceptions"
@@ -133,7 +133,7 @@
 		],
 		"xcode_settings": {
 			"OTHER_CFLAGS": [
-				"-std=c++11",
+				"-std=c++14",
 				"-stdlib=libc++"
 			],
 			"GCC_ENABLE_CPP_EXCEPTIONS": "YES",


### PR DESCRIPTION
- Resolved `electron-rebuild` issue for Electron 11~16 on macOS