### PR TITLE
feat(config): add --node-gyp-options to set up cmd options

### DIFF
--- a/install/compileLib.ts
+++ b/install/compileLib.ts
@@ -126,7 +126,7 @@ export async function compileLib(args: string[]) {
     const validAction = ['build', 'clean', 'configure', 'rebuild', 'install', 'list', 'remove']
     const action = args[args.length - 1];
     if (args.includes('--help') || args.includes('-h') || !validAction.includes(action)) {
-        console.log(`Usage: install [--version=<version>] [--vscode] [--jobs=<thread>] [--electron] [--dry-run] [--flags=<flags>] [--cuda] [--nocontrib] [--nobuild] ${validAction.join('|')}`);
+        console.log(`Usage: install [--version=<version>] [--vscode] [--jobs=<thread>] [--electron] [--node-gyp-options=<options>] [--dry-run] [--flags=<flags>] [--cuda] [--nocontrib] [--nobuild] ${validAction.join('|')}`);
         console.log(genHelp());
         return;
     }
@@ -185,7 +185,8 @@ export async function compileLib(args: string[]) {
 
     // const arch = 'x86_64' / 'x64'
     // flags += --arch=${arch} --target_arch=${arch}
-    let nodegypCmd = ''
+    const cmdOptions = options.extra['node-gyp-options'] || '';
+    flags += ` ${cmdOptions}`;
 
     const nodegyp = options.extra.electron ? 'electron-rebuild' : 'node-gyp';
 


### PR DESCRIPTION
**CLI:**

> --node-gyp-options <value>:    Config options for `node-gyp` and `electron-rebuild`

**Example:**  
```
build-opencv --electron --version 4.5.4 --node-gyp-options='--arch=arm64' build
```

** Options of Electron-Rebuild:**

https://github.com/electron/electron-rebuild#cli-arguments

**Options of Node-Gyp:**

https://github.com/nodejs/node-gyp#command-options