### PR TITLE
small typscript error fix

### DIFF
--- a/typings/Mat.d.ts
+++ b/typings/Mat.d.ts
@@ -92,7 +92,7 @@ export class OptimalNewCameraMatrix {
    * 	Optional output rectangle that outlines all-good-pixels region in the undistorted image. See roi1, roi2 description in stereoRectify .
    */
   validPixROI: Rect;
-};
+}
 
 export class Mat {
   /**


### PR DESCRIPTION
Causing errors when i tried to compile it, with the semicolon.  Specifically the tsc command.

So i just removed the unneeded ";"


Causing this error
typings/Mat.d.ts:95:2 - error TS1036: Statements are not allowed in ambient contexts