### PR TITLE
Add  resizeWindow() api

### DIFF
--- a/cc/highgui/highgui.cc
+++ b/cc/highgui/highgui.cc
@@ -16,7 +16,7 @@ NAN_MODULE_INIT(Highgui::Init) {
     Nan::SetMethod(target, "setWindowTitle", setWindowTitle);
     Nan::SetMethod(target, "moveWindow", moveWindow);
     Nan::SetMethod(target, "namedWindow", namedWindow);
-
+    Nan::SetMethod(target, "resizeWindow", resizeWindow);
 };
 
 NAN_METHOD(Highgui::setWindowProperty) {
@@ -94,7 +94,6 @@ NAN_METHOD(Highgui::getWindowProperty) {
   info.GetReturnValue().Set(Nan::New(cv::getWindowProperty(FF::StringConverter::unwrapUnchecked(info[0]), prop_id)));
 }
 
-
 NAN_METHOD(Highgui::namedWindow) {
   FF::TryCatch tryCatch("Highgui::namedWindow");
 
@@ -107,6 +106,28 @@ NAN_METHOD(Highgui::namedWindow) {
   FF::IntConverter::optArg(1, &flags, info);
   FF::StringConverter::arg(0, &winName, info);
   cv::namedWindow(FF::StringConverter::unwrapUnchecked(info[0]), flags);
+}
+
+NAN_METHOD(Highgui::resizeWindow) {
+  FF::TryCatch tryCatch("Highgui::resizeWindow");
+  int width;
+  int height;
+
+  if (!info[0]->IsString()) {
+    return tryCatch.throwError("expected arg0 to be the window name");
+  }
+
+  if (!info[1]->IsNumber()) {
+    return tryCatch.throwError("expected arg1 (width) to be a number");
+  }
+
+  if (!info[2]->IsNumber()) {
+    return tryCatch.throwError("expected arg2 (height) to be a number");
+  }
+
+  FF::IntConverter::arg(1, &width, info);
+  FF::IntConverter::arg(2, &height, info);
+  cv::resizeWindow(FF::StringConverter::unwrapUnchecked(info[0]), width, height);
 }
 
 

--- a/cc/highgui/highgui.h
+++ b/cc/highgui/highgui.h
@@ -14,6 +14,7 @@ public:
   static NAN_METHOD(setWindowTitle);
   static NAN_METHOD(moveWindow);
   static NAN_METHOD(namedWindow);
+  static NAN_METHOD(resizeWindow);
 };
 
 #endif

--- a/typings/group/highgui.d.ts
+++ b/typings/group/highgui.d.ts
@@ -64,6 +64,15 @@ export 	function namedWindow(winname: string, flags?: number): void;
 //  
 // void 	cv::resizeWindow (const String &winname, int width, int height)
 //  	Resizes the window to the specified size. More...
+/**
+ * Resize a window.
+ * https://docs.opencv.org/4.0.0/d7/dfc/group__highgui.html#gab4e70200bf54be967129cf08ac5e18bc
+ * @param winname	Name of the window.
+ * @param width	The new width of the window.
+ * @param height	The new height of the window.
+ */
+ export 	function resizeWindow(winname: string, width: number, height: number): void;
+
 //  
 // void 	cv::resizeWindow (const String &winname, const cv::Size &size)
 //  

--- a/typings/group/highgui.d.ts
+++ b/typings/group/highgui.d.ts
@@ -61,9 +61,7 @@ export 	function namedWindow(winname: string, flags?: number): void;
 
 // int 	cv::pollKey ()
 //  	Polls for a pressed key. More...
-//  
-// void 	cv::resizeWindow (const String &winname, int width, int height)
-//  	Resizes the window to the specified size. More...
+
 /**
  * Resize a window.
  * https://docs.opencv.org/4.0.0/d7/dfc/group__highgui.html#gab4e70200bf54be967129cf08ac5e18bc


### PR DESCRIPTION
This PR proposes to add the `resizeWindow()` function. 

Some devs may find this api useful, e.g., when you need to open a window prior to having an image to display. 

ref:  [opencv resizeWindow()]( https://docs.opencv.org/4.0.0/d7/dfc/group__highgui.html#gab4e70200bf54be967129cf08ac5e18bc) doc