### PR TITLE
Add startWindowThread() api

### DIFF
--- a/cc/highgui/highgui.cc
+++ b/cc/highgui/highgui.cc
@@ -17,6 +17,7 @@ NAN_MODULE_INIT(Highgui::Init) {
     Nan::SetMethod(target, "moveWindow", moveWindow);
     Nan::SetMethod(target, "namedWindow", namedWindow);
     Nan::SetMethod(target, "resizeWindow", resizeWindow);
+    Nan::SetMethod(target, "startWindowThread", startWindowThread);
 };
 
 NAN_METHOD(Highgui::setWindowProperty) {
@@ -130,5 +131,10 @@ NAN_METHOD(Highgui::resizeWindow) {
   cv::resizeWindow(FF::StringConverter::unwrapUnchecked(info[0]), width, height);
 }
 
+NAN_METHOD(Highgui::startWindowThread) {
+  FF::TryCatch tryCatch("Highgui::startWindowThread");
+  int retval = cv::startWindowThread();
+  info.GetReturnValue().Set(Nan::New(retval));
+}
 
 #endif

--- a/cc/highgui/highgui.h
+++ b/cc/highgui/highgui.h
@@ -15,6 +15,7 @@ public:
   static NAN_METHOD(moveWindow);
   static NAN_METHOD(namedWindow);
   static NAN_METHOD(resizeWindow);
+  static NAN_METHOD(startWindowThread);
 };
 
 #endif

--- a/typings/group/highgui.d.ts
+++ b/typings/group/highgui.d.ts
@@ -71,9 +71,13 @@ export 	function namedWindow(winname: string, flags?: number): void;
  */
  export 	function resizeWindow(winname: string, width: number, height: number): void;
 
-//  
-// void 	cv::resizeWindow (const String &winname, const cv::Size &size)
-//  
+/**
+ * Start a background thread that services windows events and updates
+ * without relying on waitKey(), e.g., imshow().
+ * @returns The return value;
+ */
+export  function startWindowThread(): number;
+
 // Rect 	cv::selectROI (const String &windowName, InputArray img, bool showCrosshair=true, bool fromCenter=false)
 //  	Allows users to select a ROI on the given image. More...
 //  


### PR DESCRIPTION
This PR proposes to include the HighGUI `startWindowThread()` function to service and update opencv windows, e.g,. created with imshow(). The benefit of extending the api with `startWindowThread()` is it serves as a better alternative to using cv.waitKey() to experience window updates. This is especially helpful when you don't want to block your processing with waitKey() or waitKey(1) for a quick timeout (see [S0 discussion](https://stackoverflow.com/a/68340071/3473123)).