### PR TITLE
Fix img_hash functions argument and return type

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -23,8 +23,10 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",
+    "@types/chai-arrays": "^2.0.0",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.0.0",
+    "chai-arrays": "^2.2.0",
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.4"

--- a/test/pnpm-lock.yaml
+++ b/test/pnpm-lock.yaml
@@ -2,10 +2,12 @@ lockfileVersion: 5.4
 
 specifiers:
   '@types/chai': ^4.3.1
+  '@types/chai-arrays': ^2.0.0
   '@types/mocha': ^9.1.1
   '@types/node': ^18.0.0
   '@u4/opencv4nodejs': link:..
   chai: ^4.3.6
+  chai-arrays: ^2.2.0
   istanbul: ^0.4.5
   mocha: ^10.0.0
   rimraf: ^3.0.2
@@ -20,8 +22,10 @@ dependencies:
 
 devDependencies:
   '@types/chai': 4.3.1
+  '@types/chai-arrays': 2.0.0
   '@types/mocha': 9.1.1
   '@types/node': 18.0.0
+  chai-arrays: 2.2.0
   rimraf: 3.0.2
   ts-node: 10.8.1_qiyc72axg2v44xl4yovan2v55u
   typescript: 4.7.4
@@ -65,6 +69,12 @@ packages:
 
   /@tsconfig/node16/1.0.2:
     resolution: {integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==}
+    dev: true
+
+  /@types/chai-arrays/2.0.0:
+    resolution: {integrity: sha512-5h5jnAC9C64YnD7WJpA5gBG7CppF/QmoWytOssJ6ysENllW49NBdpsTx6uuIBOpnzAnXThb8jBICgB62wezTLQ==}
+    dependencies:
+      '@types/chai': 4.3.1
     dev: true
 
   /@types/chai/4.3.1:
@@ -186,6 +196,11 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
     dev: false
+
+  /chai-arrays/2.2.0:
+    resolution: {integrity: sha512-4awrdGI2EH8owJ9I58PXwG4N56/FiM8bsn4CVSNEgr4GKAM6Kq5JPVApUbhUBjDakbZNuRvV7quRSC38PWq/tg==}
+    engines: {node: '>=0.10'}
+    dev: true
 
   /chai/4.3.6:
     resolution: {integrity: sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==}

--- a/test/tests/img_hash/imgHashTests.ts
+++ b/test/tests/img_hash/imgHashTests.ts
@@ -1,35 +1,77 @@
-import { expect } from 'chai';
-import { PHash } from '../../../typings';
-import { generateAPITests } from '../../utils/generateAPITests';
-import { TestContext } from '../model';
+import { expect } from "chai";
+import { PHash } from "../../../typings";
+import { generateAPITests } from "../../utils/generateAPITests";
+import { TestContext } from "../model";
 
 export default (args: TestContext) => (ImgHash: typeof PHash) => {
   const { getTestImg } = args;
 
-  describe('constructor', () => {
-    it('is constructable without args', () => {
+  describe("constructor", () => {
+    it("is constructable without args", () => {
       expect(() => new ImgHash()).to.not.throw();
     });
   });
 
-  describe('api tests', () => {
+  describe("api tests", () => {
     let imgHash: PHash;
 
     before(() => {
       imgHash = new ImgHash();
     });
 
-    describe('compute', () => {
+    describe("compute", () => {
       const expectOutput = (res) => {
-        expect(res).to.be.an('array');
+        expect(res).to.be.an("array");
       };
 
       generateAPITests({
         getDut: () => imgHash,
-        methodName: 'compute',
-        methodNameSpace: 'ImgHashBase',
+        methodName: "compute",
+        methodNameSpace: "ImgHashBase",
         getRequiredArgs: () => [getTestImg().bgrToGray()],
         expectOutput,
+      });
+
+      it("should compute pHash", () => {
+        const imageData = getTestImg();
+
+        const pHashValue = imgHash.compute(imageData);
+
+        expect(pHashValue).to.be.array();
+        expect(pHashValue).to.be.ofSize(8);
+        expect(pHashValue).to.be.equalTo([
+          152, 99, 43, 180, 174, 196, 101, 105,
+        ]);
+      });
+
+      it("should compute pHash in async", async () => {
+        const imageData = getTestImg();
+
+        const pHashValue = await imgHash.computeAsync(imageData);
+
+        expect(pHashValue).to.be.array();
+        expect(pHashValue).to.be.ofSize(8);
+        expect(pHashValue).to.be.equalTo([
+          152, 99, 43, 180, 174, 196, 101, 105,
+        ]);
+      });
+
+      it("should compare pHashes", () => {
+        const result = imgHash.compare(
+          [153, 99, 43, 180, 174, 196, 101, 105],
+          [152, 99, 43, 180, 174, 196, 101, 105]
+        );
+
+        expect(result).to.be.equal(1);
+      });
+
+      it("should compare pHashes in async", async () => {
+        const result = await imgHash.compareAsync(
+          [153, 99, 43, 180, 174, 196, 101, 105],
+          [152, 99, 43, 180, 174, 196, 101, 105]
+        );
+
+        expect(result).to.be.equal(1);
       });
     });
   });

--- a/test/tests/index.test.ts
+++ b/test/tests/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { expect } from 'chai';
+import chai from 'chai';
 import cv from '@u4/opencv4nodejs';
 import coreTestSuite from './core';
 import imgprocTestSuite from './imgproc';
@@ -18,6 +18,9 @@ import xfeatures2dTestSuite from './xfeatures2d';
 import ximgprocTestSuite from './ximgproc';
 import imgHashTestSuite from './img_hash';
 import { TestContext } from './model';
+
+const { expect } = chai
+chai.use(require('chai-arrays'))
 
 const modules = [
   'core', 'imgproc', 'calib3d', 'features2d', 'io',

--- a/typings/ImgHashBase.d.ts
+++ b/typings/ImgHashBase.d.ts
@@ -1,8 +1,8 @@
 import { Mat } from "./Mat.d";
 
 export class ImgHashBase {
-  compute(inputArr: Mat): string[];
-  computeAsync(inputArr: Mat): Promise<string[]>;
-  compare(hashOne: string[], hashTwo: string[]): number;
-  compareAsync(hashOne: string[], hashTwo: string[]): Promise<number>;
+  compute(inputArr: Mat): number[];
+  computeAsync(inputArr: Mat): Promise<number[]>;
+  compare(hashOne: number[], hashTwo: number[]): number;
+  compareAsync(hashOne: number[], hashTwo: number[]): Promise<number>;
 }


### PR DESCRIPTION
During adding tests, I realized `img_hash` module type definitions were wrong. I modified types to number.

\+ I added chai-arrays plugin for an efficiency of array test in chai. Please check it if it is good,