### PR TITLE
fix exception thrown on reload

### DIFF
--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const isFn = (obj) => typeof obj === 'function';
-const isAsyncFn = (fn) => fn.prototype.constructor.name.endsWith('Async');
+const isAsyncFn = (fn) => { var _a, _b, _c; return (_c = (_b = (_a = fn.prototype) === null || _a === void 0 ? void 0 : _a.constructor) === null || _b === void 0 ? void 0 : _b.name) === null || _c === void 0 ? void 0 : _c.endsWith('Async'); };
 const promisify = (fn) => function (...params) {
     if (isFn(params[params.length - 1])) {
         return fn.apply(this, params);
@@ -21,7 +21,7 @@ const promisify = (fn) => function (...params) {
 exports.default = (cv) => {
     const fns = Object.keys(cv).filter(k => isFn(cv[k])).map(k => cv[k]);
     const asyncFuncs = fns.filter(isAsyncFn);
-    const clazzes = fns.filter(fn => !!Object.keys(fn.prototype).length);
+    const clazzes = fns.filter(fn => fn.prototype && !!Object.keys(fn.prototype).length);
     clazzes.forEach((clazz) => {
         const protoFnKeys = Object.keys(clazz.prototype).filter(k => isAsyncFn(clazz.prototype[k]));
         protoFnKeys.forEach(k => clazz.prototype[k] = promisify(clazz.prototype[k]));

--- a/lib/promisify.ts
+++ b/lib/promisify.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const isFn = (obj: unknown) => typeof obj === 'function';
 
-const isAsyncFn = (fn: (...args: any[]) => any) => fn.prototype.constructor.name.endsWith('Async');
+const isAsyncFn = (fn: (...args: any[]) => any) =>
+  fn.prototype?.constructor?.name?.endsWith('Async');
 
 const promisify = (fn: () => any) => function (...params: any[]) {
   if (isFn(params[params.length - 1])) {
@@ -24,7 +25,7 @@ const promisify = (fn: () => any) => function (...params: any[]) {
 export default <T>(cv: T): T => {
   const fns = Object.keys(cv).filter(k => isFn(cv[k])).map(k => cv[k]);
   const asyncFuncs = fns.filter(isAsyncFn);
-  const clazzes = fns.filter(fn => !!Object.keys(fn.prototype).length);
+  const clazzes = fns.filter(fn => fn.prototype && !!Object.keys(fn.prototype).length);
 
   clazzes.forEach((clazz) => {
     const protoFnKeys = Object.keys(clazz.prototype).filter(k => isAsyncFn(clazz.prototype[k]));

--- a/lib/src/drawUtils.ts
+++ b/lib/src/drawUtils.ts
@@ -99,7 +99,7 @@ export default function (cv: typeof openCV): void {
     return textLines.reduce((height, textLine) => height + getLineHeight(textLine, opts), 0)
   }
 
-  cv.drawTextBox = (img: Mat, upperLeft: { x: number, y: number }, textLines: TextLines[], alpha: number): Mat => {
+  cv.drawTextBox = function drawTextBox(img: Mat, upperLeft: { x: number, y: number }, textLines: TextLines[], alpha: number): Mat {
     const padding = 10
     const linePadding = 10
 
@@ -122,7 +122,7 @@ export default function (cv: typeof openCV): void {
     return img
   }
 
-  cv.drawDetection = (img: Mat, inputRect: Rect, opts = {} as DrawParams & { segmentFraction?: number }): Rect => {
+  cv.drawDetection = function drawDetection(img: Mat, inputRect: Rect, opts = {} as DrawParams & { segmentFraction?: number }): Rect {
     const rect = inputRect.toSquare()
 
     const { x, y, width, height } = rect

--- a/lib/src/misc.ts
+++ b/lib/src/misc.ts
@@ -13,7 +13,7 @@ export default function (cv: typeof openCV): void {
      * non Natif code
      * @param type Mat type as int value
      */
-    cv.toMatTypeName = (type: number): MatTypes | undefined => {
+    cv.toMatTypeName = function toMatTypeName(type: number): MatTypes | undefined {
         for (const t of allTypes) {
             if (cv[t] === type) return t;
         }
@@ -27,7 +27,7 @@ export default function (cv: typeof openCV): void {
      * @param region search region
      * @returns a list of matchs
      */
-    cv.getScoreMax = (scoreMat: Mat, threshold: number, region?: Rect): Array<[number, number, number]> => {
+    cv.getScoreMax = function getScoreMax(scoreMat: Mat, threshold: number, region?: Rect): Array<[number, number, number]> {
         if (scoreMat.type !== cv.CV_32F)
             throw Error('this method can only be call on a CV_32F Mat');
         if (scoreMat.dims !== 2)
@@ -67,7 +67,7 @@ export default function (cv: typeof openCV): void {
      * @param matches list of matches as a list in [x,y,score]. (this data will be altered)
      * @returns best match without colisions
      */
-    cv.dropOverlappingZone = (template: Mat, matches: Array<[number, number, number]>): Array<[number, number, number]> => {
+    cv.dropOverlappingZone = function dropOverlappingZone(template: Mat, matches: Array<[number, number, number]>): Array<[number, number, number]> {
         const total = matches.length;
         const width = template.cols / 2;
         const height = template.rows / 2;


### PR DESCRIPTION
In some scenarios the JS files of the library may be reloaded, such as when loaded by Jest. It seems that the underlying node extension is not reloaded in this case. This causes an exception to be thrown when rebuilding the exported API object:

> TypeError: Cannot read properties of undefined (reading 'constructor')

This happens in the `isAsyncFn` function inside `promisify.js` because `fn.prototype` is undefined. This code works fine the first time, so why does it fail when run again? The reason is that the functions attached to the `cv` namespace are all defined in C++ and are thus essentially the equivalent of a `FunctionExpression`, which have a `prototype.constructor.name`. Calling `loadOpenCV` calls `getOpenCV` which loads the node extension, then calls `promisify` on that namespace, and finally calls `extendWithJsSources`. This is where we run into problems.

These are the functions that get added to the `cv` namespace from JS:

```
drawTextBox
drawDetection
toMatTypeName
getScoreMax
dropOverlappingZone
```

Almost all of these are defined as `ArrowFunctionExpression`s which DO NOT have a `prototype`. So after the JS files get cleared from `require.cache` by Jest or some other means, loading this library again REUSES the `cv` namespace because the node extension is not cleared from memory. But this time it has those extra functions attached, causing the exception mentioned above in `isAsyncFn`.

I changed two things to fix this:
1. make `promisify.ts` not assume that all functions have prototypes; they don't.
2. define the extra from-JS functions as `FunctionExpression`s so they will have prototypes (and names).

<hr>

Here's the simplest way I found to reproduce this issue in a project that is already using `@u4/opencv4nodejs`:

```js
$ node
> require('@u4/opencv4nodejs'); null
null
> delete require.cache[require.resolve('@u4/opencv4nodejs')]
true
> require('@u4/opencv4nodejs'); null
Uncaught TypeError: Cannot read properties of undefined (reading 'constructor')
    at isAsyncFn (/home/brian/code/scratch/opencv4nodejs-jest-issue/node_modules/@u4/opencv4nodejs/lib/promisify.js:5:40)
    at Array.filter (<anonymous>)
    at exports.default (/home/brian/code/scratch/opencv4nodejs-jest-issue/node_modules/@u4/opencv4nodejs/lib/promisify.js:23:28)
    at loadOpenCV (/home/brian/code/scratch/opencv4nodejs-jest-issue/node_modules/@u4/opencv4nodejs/lib/opencv4nodejs.js:14:44)
```