### PR TITLE
fix: imencode electron 21+ memory cage

### DIFF
--- a/cc/core/MatBindings.h
+++ b/cc/core/MatBindings.h
@@ -117,12 +117,10 @@ namespace MatBindings {
       return "";
     }
 
-    static void freeBufferCallback(char* data, void* hint) {
-      free(data);
-    }
-
     v8::Local<v8::Value> getReturnValue() {
-      return Nan::NewBuffer(data, size, freeBufferCallback, 0).ToLocalChecked();
+      v8::Local<v8::Value> copyData = Nan::CopyBuffer(data, size).ToLocalChecked();
+      free(data);
+      return copyData;
     }
   };
 

--- a/cc/io/ioBindings.h
+++ b/cc/io/ioBindings.h
@@ -79,12 +79,10 @@ namespace IoBindings {
       return FF::IntArrayConverter::optArg(2, &flags, info);
     }
 
-    static void freeBufferCallback(char* data, void* hint) {
-      free(data);
-    }
-
     v8::Local<v8::Value> getReturnValue() {
-      return Nan::NewBuffer(data, dataSize, freeBufferCallback, 0).ToLocalChecked();
+      v8::Local<v8::Value> dataCopy = Nan::CopyBuffer(data, dataSize).ToLocalChecked();
+      free(data);
+      return dataCopy;
     }
   };
 


### PR DESCRIPTION
Hi,

```imencode``` currently crashes with electron 23 because electron 21+ permits passing of buffers, instead they should be copied. I have tested the changes and they are working fine.

See: [https://www.electronjs.org/blog/v8-memory-cage](https://www.electronjs.org/blog/v8-memory-cage)