### PR TITLE
New Method setData. Directly write a Buffer into an existing Mat object.

### DIFF
--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -831,7 +831,7 @@ NAN_METHOD(Mat::SetData) {
   char *data = static_cast<char *>(node::Buffer::Data(info[0]->ToObject(Nan::GetCurrentContext()).ToLocalChecked()));
   size_t size = mat.rows * mat.cols * mat.elemSize();
   memcpy(mat.data, data, size);
-  info.GetReturnValue().Set(mat);
+  info.GetReturnValue().Set(Mat::Converter::wrap(mat));
 }
 
 NAN_METHOD(Mat::GetRegion) {

--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -141,6 +141,7 @@ NAN_MODULE_INIT(Mat::Init) {
   Nan::SetPrototypeMethod(ctor, "getData", GetData);
   Nan::SetPrototypeMethod(ctor, "getDataAsync", GetDataAsync);
   Nan::SetPrototypeMethod(ctor, "getDataAsArray", GetDataAsArray);
+  Nan::SetPrototypeMethod(ctor, "setData", SetData);
   Nan::SetPrototypeMethod(ctor, "getRegion", GetRegion);
   Nan::SetPrototypeMethod(ctor, "row", Row);
   Nan::SetPrototypeMethod(ctor, "copy", Copy);
@@ -822,6 +823,14 @@ NAN_METHOD(Mat::GetDataAsArray) {
   default: return tryCatch.throwError("not implemented yet - mat dims:" + std::to_string(mat.dims));
   }
   info.GetReturnValue().Set(rowArray);
+}
+
+NAN_METHOD(Mat::SetData) {
+	FF::TryCatch tryCatch("Mat::SetData");
+  cv::Mat mat = Mat::unwrapSelf(info);
+  char *data = static_cast<char *>(node::Buffer::Data(info[0]->ToObject(Nan::GetCurrentContext()).ToLocalChecked()));
+  size_t size = mat.rows * mat.cols * mat.elemSize();
+  memcpy(mat.data, data, size);
 }
 
 NAN_METHOD(Mat::GetRegion) {

--- a/cc/core/Mat.cc
+++ b/cc/core/Mat.cc
@@ -831,6 +831,7 @@ NAN_METHOD(Mat::SetData) {
   char *data = static_cast<char *>(node::Buffer::Data(info[0]->ToObject(Nan::GetCurrentContext()).ToLocalChecked()));
   size_t size = mat.rows * mat.cols * mat.elemSize();
   memcpy(mat.data, data, size);
+  info.GetReturnValue().Set(mat);
 }
 
 NAN_METHOD(Mat::GetRegion) {

--- a/cc/core/Mat.h
+++ b/cc/core/Mat.h
@@ -61,6 +61,7 @@ public:
   static NAN_METHOD(SetTo);
   static NAN_METHOD(SetToAsync);
   static NAN_METHOD(GetDataAsArray);
+  static NAN_METHOD(SetData);
   static NAN_METHOD(GetRegion);
   static NAN_METHOD(Norm);
   static NAN_METHOD(Row);

--- a/test/tests/core/Mat/MatTests.ts
+++ b/test/tests/core/Mat/MatTests.ts
@@ -261,6 +261,26 @@ export default function (args: TestContext) {
     });
   });
 
+  describe('setData', () => {
+    const matC1 = new cv.Mat([
+      [0, 0, 0],
+      [0, 0, 0],
+    ], cv.CV_8U);
+
+    const srcData = Buffer.from([1,2,3,4,5,6]);
+
+    describe('sync', () => {
+      it('should copy the buffer into Mat', () => {
+        matC1.setData(srcData);
+        assertDataDeepEquals([
+          [1, 2, 3],
+          [4, 5, 6],
+        ], matC1.getDataAsArray());
+      });
+    });
+
+  });
+
   describe('discrete transform', () => {
     const dtMat = new cv.Mat([
       [0.9, 0.9, 0, 0],

--- a/typings/Mat.d.ts
+++ b/typings/Mat.d.ts
@@ -414,6 +414,11 @@ export class Mat {
   gaussianBlurAsync(kSize: Size, sigmaX: number, sigmaY?: number, borderType?: number): Promise<Mat>;
   getData(): Buffer;
   getDataAsync(): Promise<Buffer>;
+  /**
+   * Copy a Buffer into an existing Mat object.
+   * The actual size written is defined by the target Mat size (mat.rows * mat.cols * mat.elemSize())
+   * @param buffer
+   */
   setData(buffer: Buffer): Mat;
 
   /**

--- a/typings/Mat.d.ts
+++ b/typings/Mat.d.ts
@@ -414,6 +414,8 @@ export class Mat {
   gaussianBlurAsync(kSize: Size, sigmaX: number, sigmaY?: number, borderType?: number): Promise<Mat>;
   getData(): Buffer;
   getDataAsync(): Promise<Buffer>;
+  setData(buffer: Buffer): Mat;
+
   /**
    * if Mat.dims <= 2
    * 


### PR DESCRIPTION
This avoid to have to recreate a Mat object each time a frame is updated. This is useful for mitigating garbage collection issues when dealing with video processing.

Note: I wasn't able to run the unit test environment.
