### PR TITLE
Allow optional newCameraMatrix in undistort

### DIFF
--- a/cc/calib3d/MatCalib3dBindings.h
+++ b/cc/calib3d/MatCalib3dBindings.h
@@ -781,10 +781,11 @@ public:
   void setup(cv::Mat self) {
     auto cameraMatrix = req<Mat::Converter>();
     auto distCoeffs = req<Mat::Converter>();
+    auto cameraMatrixNew = opt<Mat::Converter>("newCameraMatrix", cv::noArray().getMat());
     auto undistortedMat = ret<Mat::Converter>("undistortedMat");
 
     executeBinding = [=]() {
-      cv::undistort(self, undistortedMat->ref(), cameraMatrix->ref(), distCoeffs->ref());
+      cv::undistort(self, undistortedMat->ref(), cameraMatrix->ref(), distCoeffs->ref(), cameraMatrixNew->ref());
     };
   };
 };

--- a/cc/imgproc/MatImgprocBindings.h
+++ b/cc/imgproc/MatImgprocBindings.h
@@ -1991,10 +1991,11 @@ public:
   void setup(cv::Mat self) {
     auto cameraMatrix = req<Mat::Converter>();
     auto distCoeffs = req<Mat::Converter>();
+    auto cameraMatrixNew = opt<Mat::Converter>("newCameraMatrix", cv::noArray().getMat());
     auto undistortedMat = ret<Mat::Converter>("undistortedMat");
 
     executeBinding = [=]() {
-      cv::undistort(self, undistortedMat->ref(), cameraMatrix->ref(), distCoeffs->ref());
+      cv::undistort(self, undistortedMat->ref(), cameraMatrix->ref(), distCoeffs->ref(), cameraMatrixNew->ref());
     };
   };
   virtual ~Undistort() {

--- a/test/tests/calib3d/MatCalib3d.test.ts
+++ b/test/tests/calib3d/MatCalib3d.test.ts
@@ -529,11 +529,13 @@ if (toTest.calib3d) {
     describe('undistort', () => {
       const cameraMatrix = new cv.Mat([[1, 0, 10], [0, 1, 10], [0, 0, 1]], cv.CV_32F);
       const distCoeffs = new cv.Mat([[0.1, 0.1, 1, 1]], cv.CV_32F);
+      const cameraMatrixNew = new cv.Mat([[1, 0, 10], [0, 1, 10], [0, 0, 1]], cv.CV_32F);
       generateAPITests({
         getDut: () => new cv.Mat(20, 20, cv.CV_8U, 0.5),
         methodName: 'undistort',
         methodNameSpace: 'Mat',
         getRequiredArgs: () => ([cameraMatrix, distCoeffs]),
+        getOptionalArg: () => cameraMatrixNew,
         expectOutput: (res) => {
           expect(res).to.be.instanceOf(cv.Mat);
         },

--- a/test/tests/imgproc/MatImgproc.test.ts
+++ b/test/tests/imgproc/MatImgproc.test.ts
@@ -1499,11 +1499,13 @@ if (toTest.imgproc) {
     describe('undistort', () => {
       const cameraMatrix = new cv.Mat([[1, 0, 10], [0, 1, 10], [0, 0, 1]], cv.CV_32F);
       const distCoeffs = new cv.Mat([[0.1, 0.1, 1, 1]], cv.CV_32F);
+      const cameraMatrixNew = new cv.Mat([[1, 0, 10], [0, 1, 10], [0, 0, 1]], cv.CV_32F);
       generateAPITests({
         getDut: () => new cv.Mat(20, 20, cv.CV_8U, 0.5),
         methodName: 'undistort',
         methodNameSpace: 'Mat',
         getRequiredArgs: () => ([cameraMatrix, distCoeffs]),
+        getOptionalArg: () => cameraMatrixNew,
         expectOutput: (res: unknown) => {
           expect(res).to.be.instanceOf(cv.Mat);
         },

--- a/typings/Mat.d.ts
+++ b/typings/Mat.d.ts
@@ -779,9 +779,10 @@ export class Mat {
    *
    * @param cameraMatrix Input camera matrix
    * @param distCoeffs 	Input vector of distortion coefficients (k1,k2,p1,p2[,k3[,k4,k5,k6[,s1,s2,s3,s4[,τx,τy]]]]) of 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are assumed.
+   * @param newCameraMatrix Camera matrix of the distorted image. By default, it is the same as cameraMatrix but you may additionally scale and shift the result by using a different matrix.
    */
-  undistort(cameraMatrix: Mat, distCoeffs: Mat): Mat;
-  undistortAsync(cameraMatrix: Mat, distCoeffs: Mat): Promise<Mat>;
+  undistort(cameraMatrix: Mat, distCoeffs: Mat, newCameraMatrix?: Mat): Mat;
+  undistortAsync(cameraMatrix: Mat, distCoeffs: Mat, newCameraMatrix?: Mat): Promise<Mat>;
   validateDisparity(cost: Mat, minDisparity: number, numberOfDisparities: number, disp12MaxDisp?: number): void;
   validateDisparityAsync(cost: Mat, minDisparity: number, numberOfDisparities: number, disp12MaxDisp?: number): Promise<void>;
   warpAffine(transforMationMatrix: Mat, size?: Size, flags?: number, borderMode?: number, borderValue?: Vec3): Mat;


### PR DESCRIPTION
Extend API for `newCameraMatrix` in method `undistort` in modules `calib3d` and `imgproc`
