### PR TITLE
Remove constructor return type for FacemarkLBFParams.

### DIFF
--- a/typings/FacemarkLBFParams.d.ts
+++ b/typings/FacemarkLBFParams.d.ts
@@ -38,5 +38,5 @@ export class FacemarkLBFParams {
   treeDepth: number;
   treeN: number;
   readonly verbose: boolean;
-  constructor(params?: Partial<IFacemarkLBFParams>): FacemarkLBFParams;
+  constructor(params?: Partial<IFacemarkLBFParams>);
 }


### PR DESCRIPTION
This causes TS1093 “Type annotation cannot appear on a constructor declaration” error. In fact it does not seem like it was ever supported: https://github.com/microsoft/TypeScript/issues/11588